### PR TITLE
More fixes

### DIFF
--- a/src/fs.rs
+++ b/src/fs.rs
@@ -326,7 +326,7 @@ impl FsInfoSector {
         }
         let free_cluster_count = match rdr.read_u32::<LittleEndian>()? {
             0xFFFFFFFF => None,
-            // Note: BPB is required to determine if value is valid
+            // Note: value is validated in FileSystem::new function using values from BPB
             n => Some(n),
         };
         let next_free_cluster = match rdr.read_u32::<LittleEndian>()? {
@@ -335,7 +335,7 @@ impl FsInfoSector {
                 warn!("invalid next_free_cluster in FsInfo sector (values 0 and 1 are reserved)");
                 None            
             },
-            // Note: BPB is required to determine if value is valid
+            // Note: other values are validated in FileSystem::new function using values from BPB
             n => Some(n),
         };
         let mut reserved2 = [0u8; 12];

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -171,13 +171,12 @@ impl BiosParameterBlock {
             // 32k is the largest value to maintain greatest compatibility
             // Many implementations appear to support 64k per cluster, and some may support 128k or larger
             // However, >32k is not as thoroughly tested...
-            warn!("fs compatibility: bytes_per_cluster value '{}' in BPB exceeds 32k, and thus may be incompatible with some implementations", bytes_per_cluster);
             warn!("fs compatibility: bytes_per_cluster value '{}' in BPB exceeds '{}', and thus may be incompatible with some implementations", bytes_per_cluster, maximum_compatibility_bytes_per_cluster);
         }
 
         if bpb.reserved_sectors < 1 {
             return Err(Error::new(ErrorKind::Other, "invalid reserved_sectors value in BPB"));
-        } else if bpb.reserved_sectors != 1 {
+        } else if (!bpb.is_fat32()) && (bpb.reserved_sectors != 1) {
             // Microsoft document indicates fat12 and fat16 code exists that presume this value is 1
             warn!("fs compatibility: reserved_sectors value '{}' in BPB is not '1', and thus is incompatible with some implementations", bpb.reserved_sectors);
         }

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -161,11 +161,7 @@ impl BiosParameterBlock {
 
         // bytes per sector is u16, sectors per cluster is u8, so guaranteed no overflow in multiplication
         let bytes_per_cluster = bpb.bytes_per_sector as u32 * bpb.sectors_per_cluster as u32;
-        let maximum_compatibility_bytes_per_cluster : u32 = match bpb.bytes_per_sector {
-            // Per Windows 10 format.exe output, bytes_per_sector larger than 512 allow greater bytes_per_cluster
-            512 => 64 * 1024,
-            _ => 256 * 1024,
-        };
+        let maximum_compatibility_bytes_per_cluster : u32 = 32 * 1024;
 
         if bytes_per_cluster > maximum_compatibility_bytes_per_cluster  {
             // 32k is the largest value to maintain greatest compatibility
@@ -176,7 +172,7 @@ impl BiosParameterBlock {
 
         if bpb.reserved_sectors < 1 {
             return Err(Error::new(ErrorKind::Other, "invalid reserved_sectors value in BPB"));
-        } else if (!bpb.is_fat32()) && (bpb.reserved_sectors != 1) {
+        } else if !bpb.is_fat32() && bpb.reserved_sectors != 1 {
             // Microsoft document indicates fat12 and fat16 code exists that presume this value is 1
             warn!("fs compatibility: reserved_sectors value '{}' in BPB is not '1', and thus is incompatible with some implementations", bpb.reserved_sectors);
         }

--- a/src/table.rs
+++ b/src/table.rs
@@ -14,7 +14,7 @@ type Fat12 = Fat<u8>;
 type Fat16 = Fat<u16>;
 type Fat32 = Fat<u32>;
 
-const RESERVED_FAT_ENTRIES: u32 = 2;
+pub const RESERVED_FAT_ENTRIES: u32 = 2;
 
 #[derive(Copy, Clone, Eq, PartialEq, Debug)]
 enum FatValue {

--- a/src/table.rs
+++ b/src/table.rs
@@ -1,5 +1,5 @@
 use io;
-use std::io::{Error,ErrorKind};
+use io::{Error, ErrorKind};
 use byteorder::LittleEndian;
 use byteorder_ext::{ReadBytesExt, WriteBytesExt};
 
@@ -279,23 +279,17 @@ impl FatTrait for Fat32 {
     fn get<T: ReadSeek>(fat: &mut T, cluster: u32) -> io::Result<FatValue> {
         let val = Self::get_raw(fat, cluster)? & 0x0FFFFFFF;
         Ok(match val {
-            0 if cluster == 0x0FFFFFF7 => {
-                warn!("cluster number 0x0FFFFFF7 is a special value in FAT to indicate a BAD_CLUSTER; it should never be seen as free");
-                FatValue::Bad // avoid accidental use or allocation into a FAT chain
-            },
-            0 if cluster >= 0x0FFFFFF8 && cluster <= 0x0FFFFFFF => {
-                warn!("cluster number {} is a special value in FAT to indicate end-of-chain; it should never be seen as free", cluster);
+            0 if cluster >= 0x0FFFFFF7 && cluster <= 0x0FFFFFFF => {
+                let tmp = if cluster == 0x0FFFFFF7 { "BAD_CLUSTER" } else { "end-of-chain" };
+                warn!("cluster number {} is a special value in FAT to indicate {}; it should never be seen as free", cluster, tmp);
                 FatValue::Bad // avoid accidental use or allocation into a FAT chain
             },
             0 => FatValue::Free,
             0x0FFFFFF7 => FatValue::Bad,
             0x0FFFFFF8...0x0FFFFFFF => FatValue::EndOfChain,
-            n if cluster == 0x0FFFFFF7 => {
-                warn!("cluster number 0x0FFFFFF7 is special value in FAT to indicate a BAD_CLUSTER and thus should never be part of a FAT chain, but indicates next cluster is {}", n);
-                FatValue::Bad // avoid accidental use or allocation into a FAT chain
-            },
-            n if cluster >= 0x0FFFFFF8 && cluster <= 0x0FFFFFFF => {
-                warn!("cluster number {} is a special value in FAT to indicate end-of-chain and thus should never be part of a FAT chain, but indicates next cluster is {}", cluster, n);
+            n if cluster >= 0x0FFFFFF7 && cluster <= 0x0FFFFFFF => {
+                let tmp = if cluster == 0x0FFFFFF7 { "BAD_CLUSTER" } else { "end-of-chain" };
+                warn!("cluster number {} is a special value in FAT to indicate {}; hiding potential FAT chain value {} and instead reporting as a bad sector", cluster, tmp, n);
                 FatValue::Bad // avoid accidental use or allocation into a FAT chain
             },
             n => FatValue::Data(n as u32),
@@ -306,28 +300,14 @@ impl FatTrait for Fat32 {
         let old_reserved_bits = Self::get_raw(fat, cluster)? & 0xF0000000;
         fat.seek(io::SeekFrom::Start((cluster * 4) as u64))?;
 
-        match value {
-            FatValue::Free if cluster == 0x0FFFFFF7 => {
-                let msg = "cluster number 0x0FFFFFF7 is a special value in FAT to indicate a BAD_CLUSTER; it should never be marked as free";
-                let custom_error = Error::new(ErrorKind::Other, msg);
-                return Err(custom_error);
-            },
-            FatValue::Free if cluster >= 0x0FFFFFF8 && cluster <= 0x0FFFFFFF => {
-                let msg = format!("cluster number {} is a special value in FAT to indicate end-of-chain; it should never be marked as free", cluster);
-                let custom_error = Error::new(ErrorKind::Other, msg);
-                return Err(custom_error);
-            },
-            FatValue::Data(n) if cluster == 0x0FFFFFF7 => {
-                let msg = format!("cluster number 0x0FFFFFF7 is special value in FAT to indicate a BAD_CLUSTER and thus should never be part of a FAT chain; it should never store a valid next cluster {}", n);
-                let custom_error = Error::new(ErrorKind::Other, msg);
-                return Err(custom_error);
-            },
-            FatValue::Data(n) if cluster >= 0x0FFFFFF8 && cluster <= 0x0FFFFFFF => {
-                let msg = format!("cluster number {} is a special value in FAT to indicate end-of-chain and thus should never be part of a FAT chain; it should never store a valid next cluster {}", cluster, n);
-                let custom_error = Error::new(ErrorKind::Other, msg);
-                return Err(custom_error);
-            },
-            _ => value
+        if value == FatValue::Free && cluster >= 0x0FFFFFF7 && cluster <= 0x0FFFFFFF {
+            // NOTE: it is technically allowed for them to store FAT chain loops,
+            //       or even have them all store value '4' as their next cluster.
+            //       Some believe only FatValue::Bad should be allowed for this edge case.
+            let tmp = if cluster == 0x0FFFFFF7 { "BAD_CLUSTER" } else { "end-of-chain" };
+            let msg = format!("cluster number {} is a special value in FAT to indicate {}; it should never be set as free", cluster, tmp);
+            let custom_error = Error::new(ErrorKind::Other, msg);
+            return Err(custom_error);
         };
         let raw_val = match value {
             FatValue::Free => 0,


### PR DESCRIPTION
This includes the following updates:
1. reduce WARN: maximum cluster size is larger if disk uses sector size > 512 bytes, before warning of potential incompatibility.
2. reduce WARN: FAT32 may have more reserved sectors than FAT12/16
3. additional FsInfo sector validation using BPB
4. Fix rare data-loss issue with extremely large FAT32 volumes
5. Preserve reserved bits in FAT entry