### PR TITLE
fix format volume disk ownage

### DIFF
--- a/examples/mkfatfs.rs
+++ b/examples/mkfatfs.rs
@@ -10,7 +10,7 @@ use fscommon::BufStream;
 fn main() -> io::Result<()> {
     let filename = env::args().nth(1).expect("image path expected");
     let file = fs::OpenOptions::new().read(true).write(true).open(&filename)?;
-    let buf_file = BufStream::new(file);
-    fatfs::format_volume(buf_file, fatfs::FormatVolumeOptions::new())?;
+    let mut buf_file = BufStream::new(file);
+    fatfs::format_volume(&mut buf_file, fatfs::FormatVolumeOptions::new())?;
     Ok(())
 }

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -926,7 +926,7 @@ impl FormatVolumeOptions {
 /// Supplied `disk` parameter cannot be seeked (internal pointer must be on position 0).
 /// To format a fragment of a disk image (e.g. partition) library user should wrap the file struct in a struct
 /// limiting access to partition bytes only e.g. `fscommon::StreamSlice`.
-pub fn format_volume<T: ReadWriteSeek>(mut disk: T, options: FormatVolumeOptions) -> io::Result<()> {
+pub fn format_volume<T: ReadWriteSeek>(mut disk: &mut T, options: FormatVolumeOptions) -> io::Result<()> {
     trace!("format_volume");
     debug_assert!(disk.seek(SeekFrom::Current(0))? == 0);
 


### PR DESCRIPTION
Change the ownage of `format_volume` disk argument.
This way, we can format, open write manipulate volume without needing reopening the supporting file.
```rust
extern crate fatfs;
extern crate fscommon;

use std::env;
use std::fs;
use std::io;

use std::io::{prelude::*};

use fscommon::BufStream;
use fatfs::{FileSystem, FsOptions};

fn main() -> io::Result<()> {
    let filename = env::args().nth(1).expect("image path expected");
    let file = fs::OpenOptions::new().read(true).write(true).open(&filename)?;
    let mut buf_file = BufStream::new(file);
    fatfs::format_volume(&mut buf_file, fatfs::FormatVolumeOptions::new())?;

    let fs = FileSystem::new(buf_file, FsOptions::new())?;
    let mut file = fs.root_dir().create_file("hello.txt")?;
    file.write_all(b"Hello World!")?;

    Ok(())
}
```