### PR TITLE
Fix bad . .. name entries generation

### DIFF
--- a/src/dir.rs
+++ b/src/dir.rs
@@ -13,6 +13,8 @@ use dir_entry::{LFN_ENTRY_LAST_FLAG, LFN_PART_LEN};
 use file::File;
 use fs::{DiskSlice, FileSystem, FsIoAdapter, ReadWriteSeek};
 
+const SFN_PADDING: u8 = 0x20;
+
 pub(crate) enum DirRawStream<'a, T: ReadWriteSeek + 'a> {
     File(File<'a, T>),
     Root(DiskSlice<FsIoAdapter<'a, T>>),
@@ -237,10 +239,10 @@ impl<'a, T: ReadWriteSeek + 'a> Dir<'a, T> {
                 let entry = self.write_entry(name, sfn_entry)?;
                 let dir = entry.to_dir();
                 // create special entries "." and ".."
-                let dot_sfn = ShortNameGenerator::new(".").generate().unwrap();
+                let dot_sfn = ShortNameGenerator::generate_dot();
                 let sfn_entry = self.create_sfn_entry(dot_sfn, FileAttributes::DIRECTORY, entry.first_cluster());
                 dir.write_entry(".", sfn_entry)?;
-                let dotdot_sfn = ShortNameGenerator::new("..").generate().unwrap();
+                let dotdot_sfn = ShortNameGenerator::generate_dotdot();
                 let sfn_entry =
                     self.create_sfn_entry(dotdot_sfn, FileAttributes::DIRECTORY, self.stream.first_cluster());
                 dir.write_entry("..", sfn_entry)?;
@@ -900,7 +902,7 @@ struct ShortNameGenerator {
 impl ShortNameGenerator {
     fn new(name: &str) -> Self {
         // padded by ' '
-        let mut short_name = [0x20u8; 11];
+        let mut short_name = [SFN_PADDING; 11];
         // find extension after last dot
         let (basename_len, name_fits, lossy_conv) = match name.rfind('.') {
             Some(index) => {
@@ -919,6 +921,19 @@ impl ShortNameGenerator {
         };
         let chksum = Self::checksum(name);
         Self { short_name, chksum, name_fits, lossy_conv, basename_len: basename_len as u8, ..Default::default() }
+    }
+
+    fn generate_dot() -> [u8; 11] {
+        let mut short_name = [SFN_PADDING; 11];
+        short_name[0] = 0x2e;
+        short_name
+    }
+
+    fn generate_dotdot() -> [u8; 11] {
+        let mut short_name = [SFN_PADDING; 11];
+        short_name[0] = 0x2e;
+        short_name[1] = 0x2e;
+        short_name
     }
 
     fn copy_short_name_part(dst: &mut [u8], src: &str) -> (usize, bool, bool) {
@@ -1024,7 +1039,7 @@ impl ShortNameGenerator {
     }
 
     fn build_prefixed_name(&self, num: u32, with_chksum: bool) -> [u8; 11] {
-        let mut buf = [0x20u8; 11];
+        let mut buf = [SFN_PADDING; 11];
         let prefix_len = if with_chksum {
             let prefix_len = cmp::min(self.basename_len as usize, 2);
             buf[..prefix_len].copy_from_slice(&self.short_name[..prefix_len]);

--- a/tests/write.rs
+++ b/tests/write.rs
@@ -233,6 +233,13 @@ fn test_create_dir(fs: FileSystem) {
         names = subdir.iter().map(|r| r.unwrap().file_name()).collect::<Vec<String>>();
         assert_eq!(names, [".", "..", "long"]);
     }
+    // check short names validity after create_dir
+    {
+        let subdir = root_dir.create_dir("test").unwrap();
+        names = subdir.iter().map(|r| r.unwrap().short_file_name()).collect::<Vec<String>>();
+        assert_eq!(names, [".", ".."]);
+    }
+
     // check using create_dir with existing file fails
     assert!(root_dir.create_dir("very/long/path/test.txt").is_err());
 }


### PR DESCRIPTION
Hi!
When we call `create_dir`, the code generate entries for `.` and `..` with the following code:
```rust
let dot_sfn = ShortNameGenerator::new(".").generate().unwrap();
...
let dotdot_sfn = ShortNameGenerator::new("..").generate().unwrap();
```
The first entry generates in reality 11 spaces, and the second one generates `~1`  for their short names (note their corresponding long entries are ok).

This patch generates fixes the short name generation.  The bug is the actual code tests the presence of `.` to split name from extension. In our current case, the name is empty, thus, generates dual empty entries.

This patch is written with @losynix 