### PR TITLE
Refrain from using std features in byteorder

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ unicode = []
 default = ["chrono", "std", "alloc", "lfn", "unicode"]
 
 [dependencies]
-byteorder = "1"
+byteorder = { version = "1", default-features = false }
 bitflags = "1.0"
 log = "0.4"
 chrono = { version = "0.4", optional = true }


### PR DESCRIPTION
Addresses #30.