### PR TITLE
Add sync trait bound to dyn trait objects

### DIFF
--- a/src/fs.rs
+++ b/src/fs.rs
@@ -730,7 +730,7 @@ impl<'a, T> Seek for DiskSlice<T> {
 /// Provides a custom implementation for a short name encoding/decoding.
 /// Default implementation changes all non-ASCII characters to the replacement character (U+FFFD).
 /// `OemCpConverter` is specified by the `oem_cp_converter` property in `FsOptions` struct.
-pub trait OemCpConverter: Debug {
+pub trait OemCpConverter: Debug + Sync {
     fn decode(&self, oem_char: u8) -> char;
     fn encode(&self, uni_char: char) -> Option<u8>;
 }

--- a/src/time.rs
+++ b/src/time.rs
@@ -124,7 +124,7 @@ impl From<chrono::DateTime<Local>> for DateTime {
 /// Default implementation gets time from `chrono` crate if `chrono` feature is enabled.
 /// Otherwise default implementation returns DOS minimal date-time (1980/1/1 0:00:00).
 /// `TimeProvider` is specified by the `time_provider` property in `FsOptions` struct.
-pub trait TimeProvider: Debug {
+pub trait TimeProvider: Debug + Sync {
     fn get_current_date(&self) -> Date;
     fn get_current_date_time(&self) -> DateTime;
 }


### PR DESCRIPTION
This allows the FileSystem to be passed across threads.