### PR TITLE
Make FsOptions traits Sync

### DIFF
--- a/src/fs.rs
+++ b/src/fs.rs
@@ -741,7 +741,7 @@ impl<IO> Seek for DiskSlice<IO> {
 ///
 /// Provides a custom implementation for a short name encoding/decoding.
 /// `OemCpConverter` is specified by the `oem_cp_converter` property in `FsOptions` struct.
-pub trait OemCpConverter: Debug {
+pub trait OemCpConverter: Debug + Sync {
     fn decode(&self, oem_char: u8) -> char;
     fn encode(&self, uni_char: char) -> Option<u8>;
 }

--- a/src/time.rs
+++ b/src/time.rs
@@ -122,7 +122,7 @@ impl From<chrono::DateTime<Local>> for DateTime {
 ///
 /// Provides a custom implementation for a time resolution used when updating directory entry time fields.
 /// `TimeProvider` is specified by the `time_provider` property in `FsOptions` struct.
-pub trait TimeProvider: Debug {
+pub trait TimeProvider: Debug + Sync {
     fn get_current_date(&self) -> Date;
     fn get_current_date_time(&self) -> DateTime;
 }


### PR DESCRIPTION
This allows FileSystems to be used safely in multithreaded contexts.