### PR TITLE
Leverage cargo features to selectively enable logging levels

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,8 +27,19 @@ lfn = []
 alloc = []
 # Full Unicode support. Disabling it reduces code size by avoiding Unicode-aware character case conversion
 unicode = []
+# Enable only error-level logging
+log_level_error = []
+# Enable logging levels warn and up
+log_level_warn  = ["log_level_error"]
+# Enable logging levels info and up
+log_level_info  = ["log_level_warn"]
+# Enable logging levels debug and up
+log_level_debug = ["log_level_info"]
+# Enable all logging levels: trace and up 
+log_level_trace = ["log_level_debug"]
+
 # Default features
-default = ["chrono", "std", "alloc", "lfn", "unicode"]
+default = ["chrono", "std", "alloc", "lfn", "unicode", "log_level_trace"]
 
 [dependencies]
 bitflags = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -67,13 +67,15 @@
 #[macro_use]
 extern crate bitflags;
 
-#[macro_use]
 extern crate log;
 
 extern crate core;
 
 #[cfg(all(not(feature = "std"), feature = "alloc"))]
 extern crate alloc;
+
+#[macro_use]
+mod log_macros;
 
 mod boot_sector;
 mod dir;

--- a/src/log_macros.rs
+++ b/src/log_macros.rs
@@ -1,0 +1,113 @@
+//! This module offers a convenient way to enable only a subset of logging levels
+//! for just this `fatfs` crate only without changing the logging levels
+//! of other crates in a given project. 
+//!
+//! This only applies to the five level-specific logging macros:
+//! `error`, `warn`, `info`, `debug`, and `trace`. 
+//! The core `log!()` macro is unaffected.
+
+use log::LevelFilter;
+
+#[cfg(feature = "log_level_trace")]
+pub const MAX_LOG_LEVEL: LevelFilter = LevelFilter::Trace;
+
+#[cfg(all(
+    not(feature = "log_level_trace"),
+    feature = "log_level_debug",
+))]
+pub const MAX_LOG_LEVEL: LevelFilter = LevelFilter::Debug;
+
+#[cfg(all(
+    not(feature = "log_level_trace"),
+    not(feature = "log_level_debug"),
+    feature = "log_level_info",
+))]
+pub const MAX_LOG_LEVEL: LevelFilter = LevelFilter::Info;
+
+#[cfg(all(
+    not(feature = "log_level_trace"),
+    not(feature = "log_level_debug"),
+    not(feature = "log_level_info"),
+    feature = "log_level_warn",
+))]
+pub const MAX_LOG_LEVEL: LevelFilter = LevelFilter::Warn;
+
+#[cfg(all(
+    not(feature = "log_level_trace"),
+    not(feature = "log_level_debug"),
+    not(feature = "log_level_info"),
+    not(feature = "log_level_warn"),
+    feature = "log_level_error",
+))]
+pub const MAX_LOG_LEVEL: LevelFilter = LevelFilter::Error;
+
+#[cfg(all(
+    not(feature = "log_level_trace"),
+    not(feature = "log_level_debug"),
+    not(feature = "log_level_info"),
+    not(feature = "log_level_warn"),
+    not(feature = "log_level_error"),
+))]
+pub const MAX_LOG_LEVEL: LevelFilter = LevelFilter::Off;
+
+
+#[macro_export]
+macro_rules! log {
+    (target: $target:expr, $lvl:expr, $($arg:tt)+) => ({
+        let lvl = $lvl;
+        if lvl <= $crate::log_macros::MAX_LOG_LEVEL {
+            log::log!(target: $target, lvl, $($arg)+);
+        }
+    });
+    ($lvl:expr, $($arg:tt)+) => (log!(target: log::__log_module_path!(), $lvl, $($arg)+))
+}
+
+#[macro_export]
+macro_rules! error {
+    (target: $target:expr, $($arg:tt)+) => (
+        log!(target: $target, log::Level::Error, $($arg)+);
+    );
+    ($($arg:tt)+) => (
+        log!(log::Level::Error, $($arg)+);
+    )
+}
+
+#[macro_export]
+macro_rules! warn {
+    (target: $target:expr, $($arg:tt)+) => (
+        log!(target: $target, log::Level::Warn, $($arg)+);
+    );
+    ($($arg:tt)+) => (
+        log!(log::Level::Warn, $($arg)+);
+    )
+}
+
+#[macro_export]
+macro_rules! info {
+    (target: $target:expr, $($arg:tt)+) => (
+        log!(target: $target, log::Level::Info, $($arg)+);
+    );
+    ($($arg:tt)+) => (
+        log!(log::Level::Info, $($arg)+);
+    )
+}
+
+#[macro_export]
+macro_rules! debug {
+    (target: $target:expr, $($arg:tt)+) => (
+        log!(target: $target, log::Level::Debug, $($arg)+);
+    );
+    ($($arg:tt)+) => (
+        log!(log::Level::Debug, $($arg)+);
+    )
+}
+
+#[macro_export]
+macro_rules! trace {
+    (target: $target:expr, $($arg:tt)+) => (
+        log!(target: $target, log::Level::Trace, $($arg)+);
+    );
+    ($($arg:tt)+) => (
+        log!(log::Level::Trace, $($arg)+);
+    )
+}


### PR DESCRIPTION
Hi @rafalh, thanks for your excellent work creating this crate!

## Background
I've been experimenting with adding support for FAT32 filesystems in [Theseus](https://github.com/theseus-os/Theseus), my pure-Rust OS, and have successfully used this crate to do so. However, my OS uses the `log` crate copiously, with logging statements being emitted by a large variety of different sources; all of the other crates allow toggling of log statements for convenience in debugging.

I thought about just taking the simple approach of adding one coarse-grained feature that disables all logging, but then I figured it'd be nice to have warn-level or error-level log statements continue to be emitted by `fatfs` while bypassing the verbose trace-level logging that is currently emitted.

## New feature
Thus, this PR adds support for selectively enabling logging levels using cargo features. I tried a few different approaches and found that this was the best -- it effectively provides overridden versions of the key macros from the `log` crate that are used transparently across the rest of the `fatfs` crate. The cargo features are inspired by those exposed by the `log` crate itself.

The default features have been augmented to enable all log statements from the `trace` level and up, which corresponds to the current default behavior of the crate. 

Kindly let me know if you'd like me to make any changes, I'm happy to do so. 