### PR TITLE
Create volume label dir entry when formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ New features:
 * Add `Date::new`, `Time::new`, `DateTime::new` functions that instiantiate corresponding structures after ensuring
   that arguments are in the supported range. They panic if this is not the case.
 * Fix time encoding during a leap second if using `chrono`.
+* Create directory entry with `VOLUME_ID` attribute when formatting if volume label was set in `FormatVolumeOptions`.
 * Remove `byteorder` dependency.
 * Bump up minimal Rust compiler version to 1.46.0.
 * Build the crate using the 2018 edition.

--- a/tests/format.rs
+++ b/tests/format.rs
@@ -116,3 +116,27 @@ fn test_format_1gb_4096sec() {
     let fs = test_format_fs(opts, total_bytes);
     assert_eq!(fs.fat_type(), fatfs::FatType::Fat32);
 }
+
+#[test]
+fn test_format_empty_volume_label() {
+    let total_bytes = 2 * 1024 * MB;
+    let opts = fatfs::FormatVolumeOptions::new();
+    let fs = test_format_fs(opts, total_bytes);
+    assert_eq!(fs.volume_label(), "NO NAME");
+    assert_eq!(fs.read_volume_label_from_root_dir().unwrap(), None);
+}
+
+#[test]
+fn test_format_volume_label_and_id() {
+    let total_bytes = 2 * 1024 * MB;
+    let opts = fatfs::FormatVolumeOptions::new()
+        .volume_id(1234)
+        .volume_label(*b"VOLUMELABEL");
+    let fs = test_format_fs(opts, total_bytes);
+    assert_eq!(fs.volume_label(), "VOLUMELABEL");
+    assert_eq!(
+        fs.read_volume_label_from_root_dir().unwrap(),
+        Some("VOLUMELABEL".to_string())
+    );
+    assert_eq!(fs.volume_id(), 1234);
+}


### PR DESCRIPTION
Create directory entry with `VOLUME_ID` attribute when formatting if volume label was set in `FormatVolumeOptions`.
Fixes #41