### PR TITLE
Avoid using `extern crate` when not needed

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,10 +28,6 @@ Add this to your `Cargo.toml`:
     [dependencies]
     fatfs = "0.4"
 
-and this to your crate root:
-
-    extern crate fatfs;
-
 You can start using the `fatfs` library now:
 
     let img_file = File::open("fat.img")?;
@@ -43,7 +39,6 @@ You can start using the `fatfs` library now:
 Note: it is recommended to wrap the underlying file struct in a buffering/caching object like `BufStream` from
 `fscommon` crate. For example:
 
-    extern crate fscommon;
     let buf_stream = BufStream::new(img_file);
     let fs = fatfs::FileSystem::new(buf_stream, fatfs::FsOptions::new())?;
 

--- a/examples/cat.rs
+++ b/examples/cat.rs
@@ -1,6 +1,3 @@
-extern crate fatfs;
-extern crate fscommon;
-
 use std::env;
 use std::fs::File;
 use std::io::{self, prelude::*};

--- a/examples/ls.rs
+++ b/examples/ls.rs
@@ -1,7 +1,3 @@
-extern crate chrono;
-extern crate fatfs;
-extern crate fscommon;
-
 use std::env;
 use std::fs::File;
 use std::io;

--- a/examples/mkfatfs.rs
+++ b/examples/mkfatfs.rs
@@ -1,6 +1,3 @@
-extern crate fatfs;
-extern crate fscommon;
-
 use std::env;
 use std::fs;
 use std::io;

--- a/examples/partition.rs
+++ b/examples/partition.rs
@@ -1,6 +1,3 @@
-extern crate fatfs;
-extern crate fscommon;
-
 use std::{fs, io};
 
 use fatfs::{FileSystem, FsOptions};

--- a/examples/write.rs
+++ b/examples/write.rs
@@ -1,6 +1,3 @@
-extern crate fatfs;
-extern crate fscommon;
-
 use std::fs::OpenOptions;
 use std::io::{self, prelude::*};
 

--- a/src/boot_sector.rs
+++ b/src/boot_sector.rs
@@ -801,8 +801,7 @@ pub(crate) fn format_boot_sector<E: IoError>(
 #[cfg(test)]
 mod tests {
     use super::*;
-    extern crate env_logger;
-    use crate::core::u32;
+    use core::u32;
 
     fn init() {
         let _ = env_logger::builder().is_test(true).try_init();

--- a/src/dir_entry.rs
+++ b/src/dir_entry.rs
@@ -6,6 +6,7 @@ use core::fmt;
 #[cfg(not(feature = "unicode"))]
 use core::iter;
 use core::str;
+use bitflags::bitflags;
 
 #[cfg(feature = "lfn")]
 use crate::dir::LfnBuffer;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,20 +10,9 @@
 //! fatfs = "0.4"
 //! ```
 //!
-//! And this in your crate root:
-//!
-//! ```rust
-//! extern crate fatfs;
-//! ```
-//!
 //! # Examples
 //!
 //! ```rust
-//! // Declare external crates
-//! // Note: `fscommon` crate is used to speedup IO operations
-//! extern crate fatfs;
-//! extern crate fscommon;
-//!
 //! use std::io::prelude::*;
 //!
 //! fn main() -> std::io::Result<()> {
@@ -61,12 +50,7 @@
 #![allow(clippy::module_name_repetitions, clippy::cast_possible_truncation)]
 
 #[macro_use]
-extern crate bitflags;
-
-#[macro_use]
 extern crate log;
-
-extern crate core;
 
 #[cfg(all(not(feature = "std"), feature = "alloc"))]
 extern crate alloc;

--- a/tests/format.rs
+++ b/tests/format.rs
@@ -1,7 +1,3 @@
-extern crate env_logger;
-extern crate fatfs;
-extern crate fscommon;
-
 use std::io;
 use std::io::prelude::*;
 

--- a/tests/read.rs
+++ b/tests/read.rs
@@ -1,7 +1,3 @@
-extern crate env_logger;
-extern crate fatfs;
-extern crate fscommon;
-
 use std::fs;
 use std::io::prelude::*;
 use std::io::SeekFrom;

--- a/tests/write.rs
+++ b/tests/write.rs
@@ -1,7 +1,3 @@
-extern crate env_logger;
-extern crate fatfs;
-extern crate fscommon;
-
 use std::fs;
 use std::io;
 use std::io::prelude::*;


### PR DESCRIPTION
Rust 2018 allows to skip importing external crates using `extern crate` expression in most of cases so update the code and examples to take advantage of it.
`log` crate is imported the old way for now to avoid importing every level in every file using the `use` keyword.