### PR TITLE
Rid into storage trait

### DIFF
--- a/examples/cat.rs
+++ b/examples/cat.rs
@@ -2,13 +2,16 @@ use std::env;
 use std::fs::File;
 use std::io::{self, prelude::*};
 
-use fatfs::{FileSystem, FsOptions};
+use fatfs::{FsOptions, StdIoWrapper, DefaultTimeProvider, LossyOemCpConverter};
 use fscommon::BufStream;
+
+type FileSystem =
+    fatfs::FileSystem<StdIoWrapper<BufStream<File>>, DefaultTimeProvider, LossyOemCpConverter>;
 
 fn main() -> io::Result<()> {
     let file = File::open("resources/fat32.img")?;
     let buf_rdr = BufStream::new(file);
-    let fs = FileSystem::new(buf_rdr, FsOptions::new())?;
+    let fs = FileSystem::new(buf_rdr.into(), FsOptions::new())?;
     let root_dir = fs.root_dir();
     let mut file = root_dir.open_file(&env::args().nth(1).expect("filename expected"))?;
     let mut buf = vec![];

--- a/examples/ls.rs
+++ b/examples/ls.rs
@@ -3,7 +3,7 @@ use std::fs::File;
 use std::io;
 
 use chrono::{DateTime, Local};
-use fatfs::{FileSystem, FsOptions};
+use fatfs::{FileSystem, FsOptions, StdIoWrapper};
 use fscommon::BufStream;
 
 fn format_file_size(size: u64) -> String {
@@ -24,7 +24,7 @@ fn format_file_size(size: u64) -> String {
 fn main() -> io::Result<()> {
     let file = File::open("resources/fat32.img")?;
     let buf_rdr = BufStream::new(file);
-    let fs = FileSystem::new(buf_rdr, FsOptions::new())?;
+    let fs = FileSystem::new(StdIoWrapper::new(buf_rdr), FsOptions::new())?;
     let root_dir = fs.root_dir();
     let dir = match env::args().nth(1) {
         None => root_dir,

--- a/examples/partition.rs
+++ b/examples/partition.rs
@@ -1,6 +1,6 @@
 use std::{fs, io};
 
-use fatfs::{FileSystem, FsOptions};
+use fatfs::{FileSystem, FsOptions, StdIoWrapper};
 use fscommon::{BufStream, StreamSlice};
 
 fn main() -> io::Result<()> {
@@ -14,7 +14,7 @@ fn main() -> io::Result<()> {
     // Create buffered stream to optimize file access
     let buf_rdr = BufStream::new(partition);
     // Finally initialize filesystem struct using provided partition
-    let fs = FileSystem::new(buf_rdr, FsOptions::new())?;
+    let fs = FileSystem::new(StdIoWrapper::new(buf_rdr), FsOptions::new())?;
     // Read and display volume label
     println!("Volume Label: {}", fs.volume_label());
     // other operations...

--- a/examples/write.rs
+++ b/examples/write.rs
@@ -1,11 +1,11 @@
 use std::fs::OpenOptions;
 use std::io::{self, prelude::*};
 
-use fatfs::{FileSystem, FsOptions};
+use fatfs::{FileSystem, FsOptions, StdIoWrapper};
 use fscommon::BufStream;
 
 fn main() -> io::Result<()> {
-    let img_file = match OpenOptions::new().read(true).write(true).open("fat.img") {
+    let img_file = match OpenOptions::new().create(true).read(true).write(true).open("fat.img") {
         Ok(file) => file,
         Err(err) => {
             println!("Failed to open image!");
@@ -14,7 +14,8 @@ fn main() -> io::Result<()> {
     };
     let buf_stream = BufStream::new(img_file);
     let options = FsOptions::new().update_accessed_date(true);
-    let fs = FileSystem::new(buf_stream, options)?;
+    let mut disk = StdIoWrapper::new(buf_stream);
+    let fs = FileSystem::new(&mut disk, options).unwrap();
     let mut file = fs.root_dir().create_file("hello.txt")?;
     file.write_all(b"Hello World!")?;
     Ok(())

--- a/src/dir.rs
+++ b/src/dir.rs
@@ -789,6 +789,7 @@ impl LfnBuffer {
         };
         for (i, usc2_unit) in usc2_units.enumerate() {
             lfn.ucs2_units[i] = usc2_unit;
+            lfn.len += 1;
         }
         lfn
     }
@@ -807,7 +808,7 @@ impl LfnBuffer {
     }
 
     pub(crate) fn as_ucs2_units(&self) -> &[u16] {
-        &self.ucs2_units
+        &self.ucs2_units[..self.len]
     }
 }
 

--- a/src/fs.rs
+++ b/src/fs.rs
@@ -354,7 +354,7 @@ impl<IO: ReadWriteSeek, TP, OCC> FileSystem<IO, TP, OCC> {
     pub fn new(mut disk: IO, options: FsOptions<TP, OCC>) -> Result<Self, Error<IO::Error>> {
         // Make sure given image is not seeked
         trace!("FileSystem::new");
-        debug_assert!(disk.seek(SeekFrom::Current(0))? == 0);
+        disk.seek(SeekFrom::Start(0))?;
 
         // read boot sector
         let bpb = {
@@ -1104,7 +1104,7 @@ impl FormatVolumeOptions {
 #[allow(clippy::needless_pass_by_value)]
 pub fn format_volume<S: ReadWriteSeek>(mut storage: S, options: FormatVolumeOptions) -> Result<(), Error<S::Error>> {
     trace!("format_volume");
-    debug_assert!(storage.seek(SeekFrom::Current(0))? == 0);
+    storage.seek(SeekFrom::Start(0))?;
 
     let bytes_per_sector = options.bytes_per_sector.unwrap_or(512);
     let total_sectors = if let Some(total_sectors) = options.total_sectors {

--- a/src/io.rs
+++ b/src/io.rs
@@ -238,6 +238,47 @@ impl<T> From<T> for StdIoWrapper<T> {
     }
 }
 
+#[cfg(feature = "std")]
+impl<T: std::fmt::Debug> std::fmt::Debug for StdIoWrapper<T> {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("StdIoWrapper").field("inner", &self.inner).finish()
+    }
+}
+
+
+impl<T: IoBase> IoBase for &mut T {
+    type Error = T::Error;
+}
+
+impl<T: Read> Read for &mut T {
+    fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
+        T::read(self, buf)
+    }
+    fn read_exact(&mut self, buf: &mut [u8]) -> Result<(), Self::Error> {
+        T::read_exact(self, buf)
+    }
+}
+
+impl<T: Write> Write for &mut T {
+    fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
+        T::write(self, buf)
+    }
+
+    fn write_all(&mut self, buf: &[u8]) -> Result<(), Self::Error> {
+        T::write_all(self, buf)
+    }
+
+    fn flush(&mut self) -> Result<(), Self::Error> {
+        T::flush(self, )
+    }
+}
+
+impl<T: Seek> Seek for &mut T {
+    fn seek(&mut self, pos: SeekFrom) -> Result<u64, Self::Error> {
+        T::seek(self, pos.into())
+    }
+}
+
 pub(crate) trait ReadLeExt {
     type Error;
     fn read_u8(&mut self) -> Result<u8, Self::Error>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,7 +21,7 @@
 //!     let img_file = std::fs::OpenOptions::new().read(true).write(true)
 //!         .open("tmp/fat.img")?;
 //!     let buf_stream = fscommon::BufStream::new(img_file);
-//!     let fs = fatfs::FileSystem::new(buf_stream, fatfs::FsOptions::new())?;
+//!     let fs = fatfs::FileSystem::new(fatfs::StdIoWrapper::new(buf_stream), fatfs::FsOptions::new())?;
 //!     let root_dir = fs.root_dir();
 //!
 //!     // Write a file

--- a/tests/format.rs
+++ b/tests/format.rs
@@ -75,7 +75,7 @@ fn test_format_fs(opts: fatfs::FormatVolumeOptions, total_bytes: u64) -> FileSys
 
 
 #[test]
-fn corrupt() {
+fn test_recover_fs() {
     let _ = env_logger::builder().is_test(true).try_init();
     let storage_vec: Vec<u8> = vec![0xD1_u8; 1024 * 1024];
     let storage_cur = std::io::Cursor::new(storage_vec);

--- a/tests/format.rs
+++ b/tests/format.rs
@@ -1,7 +1,7 @@
 use std::io;
 use std::io::prelude::*;
 
-use fatfs::{DefaultTimeProvider, LossyOemCpConverter, StdIoWrapper};
+use fatfs::{DefaultTimeProvider, LossyOemCpConverter, StdIoWrapper, FsOptions};
 use fscommon::BufStream;
 
 const KB: u64 = 1024;
@@ -71,6 +71,20 @@ fn test_format_fs(opts: fatfs::FormatVolumeOptions, total_bytes: u64) -> FileSys
     let fs = fatfs::FileSystem::new(buffered_stream, fatfs::FsOptions::new()).expect("open fs");
     basic_fs_test(&fs);
     fs
+}
+
+
+#[test]
+fn corrupt() {
+    let _ = env_logger::builder().is_test(true).try_init();
+    let storage_vec: Vec<u8> = vec![0xD1_u8; 1024 * 1024];
+    let storage_cur = std::io::Cursor::new(storage_vec);
+    let mut disk = fatfs::StdIoWrapper::from(BufStream::new(storage_cur));
+    assert!(fatfs::FileSystem::new(&mut disk, FsOptions::new()).is_err());
+
+    fatfs::format_volume(&mut disk, fatfs::FormatVolumeOptions::new()).expect("format volume");
+
+    fatfs::FileSystem::new(&mut disk, fatfs::FsOptions::new()).expect("open fs");
 }
 
 #[test]

--- a/tests/read.rs
+++ b/tests/read.rs
@@ -17,7 +17,7 @@ fn call_with_fs<F: Fn(FileSystem) -> ()>(f: F, filename: &str) {
     let _ = env_logger::builder().is_test(true).try_init();
     let file = fs::File::open(filename).unwrap();
     let buf_file = BufStream::new(file);
-    let fs = FileSystem::new(buf_file, FsOptions::new()).unwrap();
+    let fs = FileSystem::new(StdIoWrapper::new(buf_file), FsOptions::new()).unwrap();
     f(fs);
 }
 

--- a/tests/read.rs
+++ b/tests/read.rs
@@ -1,8 +1,9 @@
 use std::fs;
 use std::io::prelude::*;
-use std::io::SeekFrom;
 use std::str;
 
+use fatfs::Seek;
+use fatfs::SeekFrom;
 use fatfs::{DefaultTimeProvider, FatType, FsOptions, LossyOemCpConverter, StdIoWrapper};
 use fscommon::BufStream;
 
@@ -17,7 +18,7 @@ fn call_with_fs<F: Fn(FileSystem) -> ()>(f: F, filename: &str) {
     let _ = env_logger::builder().is_test(true).try_init();
     let file = fs::File::open(filename).unwrap();
     let buf_file = BufStream::new(file);
-    let fs = FileSystem::new(StdIoWrapper::new(buf_file), FsOptions::new()).unwrap();
+    let fs = FileSystem::new(buf_file.into(), FsOptions::new()).unwrap();
     f(fs);
 }
 

--- a/tests/write.rs
+++ b/tests/write.rs
@@ -31,7 +31,7 @@ fn open_filesystem_rw(tmp_path: &str) -> FileSystem {
     let file = fs::OpenOptions::new().read(true).write(true).open(&tmp_path).unwrap();
     let buf_file = BufStream::new(file);
     let options = FsOptions::new().update_accessed_date(true);
-    FileSystem::new(buf_file, options).unwrap()
+    FileSystem::new(buf_file.into(), options).unwrap()
 }
 
 fn call_with_fs<F: Fn(FileSystem) -> ()>(f: F, filename: &str, test_seq: u32) {


### PR DESCRIPTION
This PR seeks to solve #54.
This is done by implementing `Read, Write, Seek, IoBase` for mutable references and removing the  `IntoStorage` trait.
This enables one to give a mutable reference to `Filesystem::new(..)`. Which can be freed up when an error occurs.

An example of recovering a corrupted filesystem can be seen in [/tests/format.rs#L78](https://github.com/MathiasKoch/rust-fatfs/blob/08da64c50e35217d5e9fb876802ee9ab1c0a8613/tests/format.rs#L78).