### PR TITLE
Create volume label dir entry when formatting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changelog
 =========
 
+0.3.6 (not released yet)
+------------------------
+Bug fixes:
+* Create directory entry with `VOLUME_ID` attribute when formatting if volume label was set in `FormatVolumeOptions`.
+
 0.3.5 (2021-01-23)
 ------------------------
 Bug fixes:

--- a/tests/format.rs
+++ b/tests/format.rs
@@ -108,3 +108,27 @@ fn test_format_512mb_4096sec() {
     let fs = test_format_fs(opts, total_bytes);
     assert_eq!(fs.fat_type(), fatfs::FatType::Fat32);
 }
+
+#[test]
+fn test_format_empty_volume_label() {
+    let total_bytes = 2 * 1024 * MB;
+    let opts = fatfs::FormatVolumeOptions::new();
+    let fs = test_format_fs(opts, total_bytes);
+    assert_eq!(fs.volume_label(), "NO NAME");
+    assert_eq!(fs.read_volume_label_from_root_dir().unwrap(), None);
+}
+
+#[test]
+fn test_format_volume_label_and_id() {
+    let total_bytes = 2 * 1024 * MB;
+    let opts = fatfs::FormatVolumeOptions::new()
+        .volume_id(1234)
+        .volume_label(*b"VOLUMELABEL");
+    let fs = test_format_fs(opts, total_bytes);
+    assert_eq!(fs.volume_label(), "VOLUMELABEL");
+    assert_eq!(
+        fs.read_volume_label_from_root_dir().unwrap(),
+        Some("VOLUMELABEL".to_string())
+    );
+    assert_eq!(fs.volume_id(), 1234);
+}


### PR DESCRIPTION
Backport https://github.com/rafalh/rust-fatfs/pull/45 to 0.3.x