### PR TITLE
Fix bug in geometry determination

### DIFF
--- a/tests/format.rs
+++ b/tests/format.rs
@@ -94,7 +94,7 @@ fn test_format_50mb() {
     let total_bytes = 50 * MB;
     let opts = fatfs::FormatVolumeOptions::new();
     let fs = test_format_fs(opts, total_bytes);
-    assert_eq!(fs.fat_type(), fatfs::FatType::Fat16);
+    assert_eq!(fs.fat_type(), fatfs::FatType::Fat32);
 }
 
 #[test]


### PR DESCRIPTION
Formatting a FAT volume fails with particular volume sizes due to a bug in the logic used to determine the geometry of the volume.

Specifically, when the FatType isn't specified, a heuristic is applied to guess the type based on the volume size.  This guessed type doesn't match up against the actual type determined to "fit" the volume in determine_fs_geometry, which makes it so that none of the possible FatTypes are usable.

Note that this results in a user-visible behaviour change: if a FatType is specified as a format option, it will be strictly respected.

Added a regression test for a specific volume size that fails in this manner.