### PR TITLE
feature/embedded-io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,7 @@ default = ["chrono", "std", "alloc", "lfn", "unicode", "log_level_trace"]
 bitflags = "1.0"
 log = "0.4"
 chrono = { version = "0.4", default-features = false, features = ["clock"], optional = true }
+embedded-io = { version = "0.4.0", optional = true }
 
 [dev-dependencies]
 env_logger = "0.9"


### PR DESCRIPTION
Adds a blanket `fatfs::io::*` implementation for anything that implements the embedded-io traits.`embedded_io::ErrorKind` only has `ErrorKind::Other` at the moment, but in the future when this populated we can come back and improve this error.

I did contemplate replacing the io module completely with embedded-io, the only part that doesn't slot in perfectly is the error module. Happy to PR those changes instead, if you think that would work. It might also pave the way for some async support in the future.