### PR TITLE
Replace `fatfs::io` traits with `embedded-io` traits

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ exclude = [
 
 [features]
 # Use Rust std library
-std = []
+std = ["embedded-io/std"]
 # LFN (Long File Name) support
 lfn = []
 # Use dynamic allocation. When used without std please enable core_io/collections
@@ -41,6 +41,7 @@ default = ["chrono", "std", "alloc", "lfn", "unicode", "log_level_trace"]
 [dependencies]
 bitflags = "1.0"
 log = "0.4"
+embedded-io = "0.4.0"
 chrono = { version = "0.4", default-features = false, features = ["clock"], optional = true }
 
 [dev-dependencies]

--- a/src/dir.rs
+++ b/src/dir.rs
@@ -1,5 +1,6 @@
 #[cfg(all(not(feature = "std"), feature = "alloc", feature = "lfn"))]
 use alloc::vec::Vec;
+
 use core::char;
 use core::cmp;
 use core::num;

--- a/src/dir_entry.rs
+++ b/src/dir_entry.rs
@@ -1,5 +1,3 @@
-#[cfg(all(not(feature = "std"), feature = "alloc"))]
-use alloc::string::String;
 use bitflags::bitflags;
 use core::char;
 use core::convert::TryInto;
@@ -8,10 +6,13 @@ use core::fmt;
 use core::iter;
 use core::str;
 
+#[cfg(all(not(feature = "std"), feature = "alloc", feature = "lfn"))]
+use alloc::string::String;
+
 #[cfg(feature = "lfn")]
 use crate::dir::LfnBuffer;
 use crate::dir::{Dir, DirRawStream};
-use crate::error::{Error, IoError};
+use crate::error::{Error, IoError, ReadExactError};
 use crate::file::File;
 use crate::fs::{FatType, FileSystem, OemCpConverter, ReadWriteSeek};
 use crate::io::{self, Read, ReadLeExt, Write, WriteLeExt};
@@ -375,17 +376,20 @@ impl DirEntryData {
         }
     }
 
-    pub(crate) fn deserialize<E: IoError, R: Read<Error = Error<E>>>(rdr: &mut R) -> Result<Self, Error<E>> {
+    pub(crate) fn deserialize<E: IoError, R: Read<Error = Error<E>>>(rdr: &mut R) -> Result<Self, Error<E>>
+    where
+        R::Error: From<ReadExactError<R::Error>>,
+    {
         trace!("DirEntryData::deserialize");
         let mut name = [0; SFN_SIZE];
         match rdr.read_exact(&mut name) {
-            Err(Error::UnexpectedEof) => {
+            Err(ReadExactError::UnexpectedEof) => {
                 // entries can occupy all clusters of directory so there is no zero entry at the end
                 // handle it here by returning non-existing empty entry
                 return Ok(DirEntryData::File(DirFileEntryData::default()));
             }
             Err(err) => {
-                return Err(err);
+                return Err(err.into());
             }
             Ok(_) => {}
         }

--- a/src/file.rs
+++ b/src/file.rs
@@ -473,12 +473,12 @@ impl<IO: ReadWriteSeek, TP, OCC> Seek for File<'_, IO, TP, OCC> {
     }
 }
 
-#[cfg(feature = "std")]
+#[cfg(test)]
 impl<IO: ReadWriteSeek, TP: TimeProvider, OCC> std::io::Seek for File<'_, IO, TP, OCC>
 where
     std::io::Error: From<Error<IO::Error>>,
 {
     fn seek(&mut self, pos: std::io::SeekFrom) -> std::io::Result<u64> {
-        Ok(Seek::seek(self, pos.into())?)
+        Ok(Seek::seek(self, crate::StdSeekPosWrapper::from(pos).into())?)
     }
 }

--- a/src/io.rs
+++ b/src/io.rs
@@ -1,177 +1,12 @@
-use crate::error::IoError;
-
-/// Provides IO error as an associated type.
-///
-/// Must be implemented for all types that also implement at least one of the following traits: `Read`, `Write`,
-/// `Seek`.
-pub trait IoBase {
-    /// Type of errors returned by input/output operations.
-    type Error: IoError;
-}
-
-/// The `Read` trait allows for reading bytes from a source.
-///
-/// It is based on the `std::io::Read` trait.
-pub trait Read: IoBase {
-    /// Pull some bytes from this source into the specified buffer, returning how many bytes were read.
-    ///
-    /// This function does not provide any guarantees about whether it blocks waiting for data, but if an object needs
-    /// to block for a read and cannot, it will typically signal this via an Err return value.
-    ///
-    /// If the return value of this method is `Ok(n)`, then it must be guaranteed that `0 <= n <= buf.len()`. A nonzero
-    /// `n` value indicates that the buffer buf has been filled in with n bytes of data from this source. If `n` is
-    /// `0`, then it can indicate one of two scenarios:
-    ///
-    /// 1. This reader has reached its "end of file" and will likely no longer be able to produce bytes. Note that this
-    ///    does not mean that the reader will always no longer be able to produce bytes.
-    /// 2. The buffer specified was 0 bytes in length.
-    ///
-    /// It is not an error if the returned value `n` is smaller than the buffer size, even when the reader is not at
-    /// the end of the stream yet. This may happen for example because fewer bytes are actually available right now
-    /// (e. g. being close to end-of-file) or because read() was interrupted by a signal.
-    ///
-    /// # Errors
-    ///
-    /// If this function encounters any form of I/O or other error, an error will be returned. If an error is returned
-    /// then it must be guaranteed that no bytes were read.
-    /// An error for which `IoError::is_interrupted` returns true is non-fatal and the read operation should be retried
-    /// if there is nothing else to do.
-    fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error>;
-
-    /// Read the exact number of bytes required to fill `buf`.
-    ///
-    /// This function reads as many bytes as necessary to completely fill the specified buffer `buf`.
-    ///
-    /// # Errors
-    ///
-    /// If this function encounters an error for which `IoError::is_interrupted` returns true then the error is ignored
-    /// and the operation will continue.
-    ///
-    /// If this function encounters an end of file before completely filling the buffer, it returns an error
-    /// instantiated by a call to `IoError::new_unexpected_eof_error`. The contents of `buf` are unspecified in this
-    /// case.
-    ///
-    /// If this function returns an error, it is unspecified how many bytes it has read, but it will never read more
-    /// than would be necessary to completely fill the buffer.
-    fn read_exact(&mut self, mut buf: &mut [u8]) -> Result<(), Self::Error> {
-        while !buf.is_empty() {
-            match self.read(buf) {
-                Ok(0) => break,
-                Ok(n) => {
-                    let tmp = buf;
-                    buf = &mut tmp[n..];
-                }
-                Err(ref e) if e.is_interrupted() => {}
-                Err(e) => return Err(e),
-            }
-        }
-        if buf.is_empty() {
-            Ok(())
-        } else {
-            debug!("failed to fill whole buffer in read_exact");
-            Err(Self::Error::new_unexpected_eof_error())
-        }
-    }
-}
-
-/// The `Write` trait allows for writing bytes into the sink.
-///
-/// It is based on the `std::io::Write` trait.
-pub trait Write: IoBase {
-    /// Write a buffer into this writer, returning how many bytes were written.
-    ///
-    /// # Errors
-    ///
-    /// Each call to write may generate an I/O error indicating that the operation could not be completed. If an error
-    /// is returned then no bytes in the buffer were written to this writer.
-    /// It is not considered an error if the entire buffer could not be written to this writer.
-    fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error>;
-
-    /// Attempts to write an entire buffer into this writer.
-    ///
-    /// This method will continuously call `write` until there is no more data to be written or an error is returned.
-    /// Errors for which `IoError::is_interrupted` method returns true are being skipped. This method will not return
-    /// until the entire buffer has been successfully written or such an error occurs.
-    /// If `write` returns 0 before the entire buffer has been written this method will return an error instantiated by
-    /// a call to `IoError::new_write_zero_error`.
-    ///
-    /// # Errors
-    ///
-    /// This function will return the first error for which `IoError::is_interrupted` method returns false that `write`
-    /// returns.
-    fn write_all(&mut self, mut buf: &[u8]) -> Result<(), Self::Error> {
-        while !buf.is_empty() {
-            match self.write(buf) {
-                Ok(0) => {
-                    debug!("failed to write whole buffer in write_all");
-                    return Err(Self::Error::new_write_zero_error());
-                }
-                Ok(n) => buf = &buf[n..],
-                Err(ref e) if e.is_interrupted() => {}
-                Err(e) => return Err(e),
-            }
-        }
-        Ok(())
-    }
-
-    /// Flush this output stream, ensuring that all intermediately buffered contents reach their destination.
-    ///
-    /// # Errors
-    ///
-    /// It is considered an error if not all bytes could be written due to I/O errors or EOF being reached.
-    fn flush(&mut self) -> Result<(), Self::Error>;
-}
-
-/// Enumeration of possible methods to seek within an I/O object.
-///
-/// It is based on the `std::io::SeekFrom` enum.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum SeekFrom {
-    /// Sets the offset to the provided number of bytes.
-    Start(u64),
-    /// Sets the offset to the size of this object plus the specified number of bytes.
-    End(i64),
-    /// Sets the offset to the current position plus the specified number of bytes.
-    Current(i64),
-}
-
-/// The `Seek` trait provides a cursor which can be moved within a stream of bytes.
-///
-/// It is based on the `std::io::Seek` trait.
-pub trait Seek: IoBase {
-    /// Seek to an offset, in bytes, in a stream.
-    ///
-    /// A seek beyond the end of a stream or to a negative position is not allowed.
-    ///
-    /// If the seek operation completed successfully, this method returns the new position from the start of the
-    /// stream. That position can be used later with `SeekFrom::Start`.
-    ///
-    /// # Errors
-    /// Seeking to a negative offset is considered an error.
-    fn seek(&mut self, pos: SeekFrom) -> Result<u64, Self::Error>;
-}
+use crate::error::ReadExactError;
 
 #[cfg(feature = "std")]
-impl From<SeekFrom> for std::io::SeekFrom {
-    fn from(from: SeekFrom) -> Self {
-        match from {
-            SeekFrom::Start(n) => std::io::SeekFrom::Start(n),
-            SeekFrom::End(n) => std::io::SeekFrom::End(n),
-            SeekFrom::Current(n) => std::io::SeekFrom::Current(n),
-        }
-    }
-}
+use crate::{ErrorKind, IoError};
 
-#[cfg(feature = "std")]
-impl From<std::io::SeekFrom> for SeekFrom {
-    fn from(from: std::io::SeekFrom) -> Self {
-        match from {
-            std::io::SeekFrom::Start(n) => SeekFrom::Start(n),
-            std::io::SeekFrom::End(n) => SeekFrom::End(n),
-            std::io::SeekFrom::Current(n) => SeekFrom::Current(n),
-        }
-    }
-}
+pub use embedded_io::Io as IoBase;
+pub use embedded_io::SeekFrom;
+
+pub use embedded_io::blocking::{Read, Seek, Write};
 
 /// A wrapper struct for types that have implementations for `std::io` traits.
 ///
@@ -196,39 +31,132 @@ impl<T> StdIoWrapper<T> {
 }
 
 #[cfg(feature = "std")]
+#[derive(Debug)]
+pub struct StdErrWrapper {}
+
+#[cfg(feature = "std")]
+#[derive(Debug)]
+pub enum StdSeekPosWrapper {
+    Start(u64),
+    End(i64),
+    Current(i64),
+}
+
+#[cfg(feature = "std")]
+impl From<embedded_io::SeekFrom> for StdSeekPosWrapper {
+    fn from(pos: embedded_io::SeekFrom) -> Self {
+        match pos {
+            embedded_io::SeekFrom::Start(pos) => Self::Start(pos),
+            embedded_io::SeekFrom::End(pos) => Self::End(pos),
+            embedded_io::SeekFrom::Current(pos) => Self::Current(pos),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl From<std::io::SeekFrom> for StdSeekPosWrapper {
+    fn from(pos: std::io::SeekFrom) -> Self {
+        match pos {
+            std::io::SeekFrom::Start(pos) => Self::Start(pos),
+            std::io::SeekFrom::End(pos) => Self::End(pos),
+            std::io::SeekFrom::Current(pos) => Self::Current(pos),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl Into<std::io::SeekFrom> for StdSeekPosWrapper {
+    fn into(self) -> std::io::SeekFrom {
+        match self {
+            Self::Start(pos) => std::io::SeekFrom::Start(pos),
+            Self::End(pos) => std::io::SeekFrom::End(pos),
+            Self::Current(pos) => std::io::SeekFrom::Current(pos),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl Into<embedded_io::SeekFrom> for StdSeekPosWrapper {
+    fn into(self) -> embedded_io::SeekFrom {
+        match self {
+            Self::Start(pos) => embedded_io::SeekFrom::Start(pos),
+            Self::End(pos) => embedded_io::SeekFrom::End(pos),
+            Self::Current(pos) => embedded_io::SeekFrom::Current(pos),
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl From<std::io::Error> for StdErrWrapper {
+    fn from(_: std::io::Error) -> Self {
+        Self {}
+    }
+}
+
+#[cfg(feature = "std")]
+impl Into<std::io::Error> for StdErrWrapper {
+    fn into(self) -> std::io::Error {
+        std::io::Error::new(std::io::ErrorKind::Other, StdErrWrapper {})
+    }
+}
+
+#[cfg(feature = "std")]
+impl From<ReadExactError<StdErrWrapper>> for StdErrWrapper {
+    fn from(_: ReadExactError<StdErrWrapper>) -> Self {
+        Self {}
+    }
+}
+
+#[cfg(feature = "std")]
+impl IoError for StdErrWrapper {
+    fn kind(&self) -> ErrorKind {
+        ErrorKind::Other
+    }
+}
+
+#[cfg(feature = "std")]
 impl<T> IoBase for StdIoWrapper<T> {
-    type Error = std::io::Error;
+    type Error = StdErrWrapper;
 }
 
 #[cfg(feature = "std")]
 impl<T: std::io::Read> Read for StdIoWrapper<T> {
     fn read(&mut self, buf: &mut [u8]) -> Result<usize, Self::Error> {
-        self.inner.read(buf)
+        Ok(self.inner.read(buf)?)
     }
-    fn read_exact(&mut self, buf: &mut [u8]) -> Result<(), Self::Error> {
-        self.inner.read_exact(buf)
+    fn read_exact(&mut self, buf: &mut [u8]) -> Result<(), ReadExactError<Self::Error>>
+    where
+        Self::Error: From<ReadExactError<Self::Error>>,
+    {
+        match self.inner.read_exact(buf) {
+            Ok(()) => Ok(()),
+            Err(error) => match error.kind() {
+                std::io::ErrorKind::UnexpectedEof => Err(ReadExactError::UnexpectedEof),
+                _ => Err(ReadExactError::Other(error.into())),
+            },
+        }
     }
 }
 
 #[cfg(feature = "std")]
 impl<T: std::io::Write> Write for StdIoWrapper<T> {
     fn write(&mut self, buf: &[u8]) -> Result<usize, Self::Error> {
-        self.inner.write(buf)
+        Ok(self.inner.write(buf)?)
     }
 
     fn write_all(&mut self, buf: &[u8]) -> Result<(), Self::Error> {
-        self.inner.write_all(buf)
+        Ok(self.inner.write_all(buf)?)
     }
 
     fn flush(&mut self) -> Result<(), Self::Error> {
-        self.inner.flush()
+        Ok(self.inner.flush()?)
     }
 }
 
 #[cfg(feature = "std")]
 impl<T: std::io::Seek> Seek for StdIoWrapper<T> {
     fn seek(&mut self, pos: SeekFrom) -> Result<u64, Self::Error> {
-        self.inner.seek(pos.into())
+        Ok(self.inner.seek(StdSeekPosWrapper::from(pos).into())?)
     }
 }
 
@@ -246,7 +174,10 @@ pub(crate) trait ReadLeExt {
     fn read_u32_le(&mut self) -> Result<u32, Self::Error>;
 }
 
-impl<T: Read> ReadLeExt for T {
+impl<T: Read> ReadLeExt for T
+where
+    <T as IoBase>::Error: From<ReadExactError<<T as IoBase>::Error>>,
+{
     type Error = <Self as IoBase>::Error;
 
     fn read_u8(&mut self) -> Result<u8, Self::Error> {

--- a/src/time.rs
+++ b/src/time.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 #[cfg(feature = "chrono")]
 use core::convert::TryFrom;
 use core::fmt::Debug;

--- a/tests/read.rs
+++ b/tests/read.rs
@@ -1,9 +1,8 @@
 use std::fs;
 use std::io::prelude::*;
-use std::io::SeekFrom;
 use std::str;
 
-use fatfs::{DefaultTimeProvider, FatType, FsOptions, LossyOemCpConverter, StdIoWrapper};
+use fatfs::{DefaultTimeProvider, FatType, FsOptions, LossyOemCpConverter, Seek, SeekFrom, StdIoWrapper};
 use fscommon::BufStream;
 
 const TEST_TEXT: &str = "Rust is cool!\n";

--- a/tests/write.rs
+++ b/tests/write.rs
@@ -1,10 +1,9 @@
 use std::fs;
-use std::io;
 use std::io::prelude::*;
 use std::mem;
 use std::str;
 
-use fatfs::{DefaultTimeProvider, FsOptions, LossyOemCpConverter, StdIoWrapper};
+use fatfs::{DefaultTimeProvider, FsOptions, LossyOemCpConverter, Seek, SeekFrom, StdIoWrapper};
 use fscommon::BufStream;
 
 const FAT12_IMG: &str = "fat12.img";
@@ -47,7 +46,7 @@ fn test_write_short_file(fs: FileSystem) {
     let mut file = root_dir.open_file("short.txt").expect("open file");
     file.truncate().unwrap();
     file.write_all(&TEST_STR.as_bytes()).unwrap();
-    file.seek(io::SeekFrom::Start(0)).unwrap();
+    file.seek(SeekFrom::Start(0)).unwrap();
     let mut buf = Vec::new();
     file.read_to_end(&mut buf).unwrap();
     assert_eq!(TEST_STR, str::from_utf8(&buf).unwrap());
@@ -74,13 +73,13 @@ fn test_write_long_file(fs: FileSystem) {
     file.truncate().unwrap();
     let test_str = TEST_STR.repeat(1000);
     file.write_all(&test_str.as_bytes()).unwrap();
-    file.seek(io::SeekFrom::Start(0)).unwrap();
+    file.seek(SeekFrom::Start(0)).unwrap();
     let mut buf = Vec::new();
     file.read_to_end(&mut buf).unwrap();
     assert_eq!(test_str, str::from_utf8(&buf).unwrap());
-    file.seek(io::SeekFrom::Start(1234)).unwrap();
+    file.seek(SeekFrom::Start(1234)).unwrap();
     file.truncate().unwrap();
-    file.seek(io::SeekFrom::Start(0)).unwrap();
+    file.seek(SeekFrom::Start(0)).unwrap();
     buf.clear();
     file.read_to_end(&mut buf).unwrap();
     assert_eq!(&test_str[..1234], str::from_utf8(&buf).unwrap());


### PR DESCRIPTION
This slotted in fairly easily, due to how similar the two sets of traits were. The only real difference is how `UnexpectedEof` is handled. Previously this crate had methods on the `IoError` trait to create an `UnexpectedEof` error, in embedded-io the `read_exact` method actually returns an entirely different enum, one which handles the `UnexpectedEof` or other io errors.

I believe this is a good change, for a number of reasons. Firstly embedded-io is almost a drop-in solution, and by switching more of the ecosystem can use this crate. embedded-io [is established in the community](https://crates.io/crates/embedded-io/reverse_dependencies) and growing in popularity. embedded-io has a set of  async traits which may allow this crate to take advantage of async io in the future. 