### PR TITLE
Don't create LFNs for . and ..

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,7 @@ New features:
 Bug fixes:
 * Fix formatting volumes with size in range 4096-4199 KB
 * Always respect `fat_type` from `FormatVolumeOptions`
+* Put '.' and '..' in the first two directory entries. (fixes "Expected a valid '.' entry in this slot." fsck error)
 
 0.3.4 (2020-07-20)
 ------------------


### PR DESCRIPTION
The current code makes invalid dir entries, because the first two slots should be . and .., but with LFNs, it's

1.     LFN for .
2.     .
3.     LFN for ..
4.     ..

We should probably not create LFN's when not needed anyway, but that's not implemented in this patch.

`fsck` output for the current code:

```
fsck from util-linux 2.40.2
fsck.fat 4.2 (2021-01-31)
/home/A.
  Expected a valid '.' entry in this slot.
  Moving entry down.
/home/.
  Expected a valid '..' entry in this slot.
  Moving entry down.
/home/..
  Bad short file name (..).
  Auto-renaming it.
  Renamed to FSCK0000.000
/home/.
  Bad short file name (.).
  Auto-renaming it.
  Renamed to FSCK0000.001
/  and
/home/FSCK0000.000
  share clusters.
  Truncating second to 0 bytes because first is FAT32 root dir.
/home/FSCK0000.001
 Start does point to containing directory. Deleting entry.
```